### PR TITLE
Update jsss-compiler version to 1.3.2 from 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/MisumiRize/react-jsss",
   "dependencies": {
-    "jsss-compiler": "^1.2.1"
+    "jsss-compiler": "^1.3.2"
   },
   "devDependencies": {
     "babel": "^4.4.2",


### PR DESCRIPTION
Hi, thanks for the interesting repository you created. I just updated jsss-compiler version to 1.3.2 from 1.2.1 and here is a changelog for you:
- https://github.com/watilde/jsss-compiler/pull/44
- https://github.com/watilde/jsss-compiler/pull/45
- https://github.com/watilde/jsss-compiler/pull/46

Cheers!
